### PR TITLE
fix: add GET localhost login method for CLI login

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const debug = require('debug')('aio-lib-ims-oauth/login')
 const ora = require('ora')
 const { cli } = require('cli-ux')
-const { randomId, authSiteUrl, createServer, handleOPTIONS, handlePOST, handleUnsupportedHttpMethod } = require('./helpers')
+const { randomId, authSiteUrl, createServer, handleOPTIONS, handleGET, handlePOST, handleUnsupportedHttpMethod } = require('./helpers')
 
 const AUTH_TIMEOUT_SECONDS = 120
 
@@ -26,6 +26,7 @@ const AUTH_TIMEOUT_SECONDS = 120
  * @param {string} [options.client_id] the client id of the OAuth2 integration
  * @param {string} [options.scope] the scope of the OAuth2 integration
  * @param {string} [options.redirect_uri] the redirect uri of the OAuth2 integration
+ * @returns {Promise} resolves to an access token/auth code
  */
 async function login (options) {
   // eslint-disable-next-line camelcase
@@ -71,6 +72,11 @@ async function login (options) {
             return handleOPTIONS(request, response, env)
           case 'POST': {
             const result = await handlePOST(request, response, id, cleanup, env)
+            resolve(result)
+          }
+            break
+          case 'GET': {
+            const result = await handleGET(request, response, id, cleanup, env)
             resolve(result)
           }
             break


### PR DESCRIPTION
For Safari browsers.
See https://github.com/adobe/aio-cli-plugin-auth/issues/44

## How Has This Been Tested?

npm test
`aio login` (stage) test via Safari browser (falls back to GET link)
`aio login` (stage) test via Chrome Mac browser (does POST)
`aio login` (stage) test via Firefox Mac browser (does POST)
`aio login` (stage) test via Edge Mac browser (does POST)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
