### PR TITLE
feat: support specifying browser for URL opening. fixes #43

### DIFF
--- a/src/ims-cli.js
+++ b/src/ims-cli.js
@@ -73,7 +73,7 @@ async function imsLogin (ims, config) {
   aioLogger.debug(`imsLogin config: ${JSON.stringify(config)}`)
   return canSupport(config)
     .then(() => {
-      const options = { bare: config[CLI_BARE_OUTPUT], env: config.env, timeout: config.timeout, open: config.open }
+      const options = { bare: config[CLI_BARE_OUTPUT], env: config.env, timeout: config.timeout, open: config.open, browser: config.browser }
       return login(options)
     })
 }

--- a/src/login.js
+++ b/src/login.js
@@ -34,7 +34,7 @@ async function login (options) {
   aioLogger.debug(`login options: ${JSON.stringify(options)}`)
 
   // eslint-disable-next-line camelcase
-  const { bare = false, env, timeout = AUTH_TIMEOUT_SECONDS, client_id, scope, open = true } = options
+  const { bare = false, env, timeout = AUTH_TIMEOUT_SECONDS, client_id, scope, open = true, browser: app } = options
   const redirect_uri = `${getImsCliOAuthUrl(env)}${LOGIN_SUCCESS}` // eslint-disable-line camelcase
   const id = randomId()
   const server = await createServer()
@@ -52,7 +52,9 @@ async function login (options) {
       spinner = ora('Waiting for browser login').start()
     }
     if (open) {
-      cli.open(uri)
+      cli.open(uri, {
+        app
+      })
     }
 
     const timerId = setTimeout(() => {

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -258,3 +258,18 @@ test('OPTIONS http method', () => {
     login(gConfig)
   })
 })
+
+test('test browser config is passed to open', async () => {
+  const request = { method: 'GET' }
+  helpers.createServer.mockImplementation(() => {
+    return new Promise(resolve => {
+      resolve(createMockServer(request, createMockResponse()))
+    })
+  })
+
+  await login({ browser: 'Firefox', ...gConfig })
+  expect(cli.open.mock.calls.length).toEqual(1)
+
+  const openOptions = cli.open.mock.calls[0][1]
+  expect(openOptions.app).toEqual('Firefox')
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Read `browser` key out of config object and pass it to `cli.open`

## Related Issue

#43 

## Motivation and Context

See https://github.com/adobe/aio-cli-plugin-auth/issues/62

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
