### PR TITLE
fix: incorrect usage of CliUx

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@adobe/aio-lib-core-logging": "^2.0.0",
     "@adobe/aio-lib-env": "^2.0.0",
     "@oclif/core": "^1.14.2",
-    "cli-ux": "^5.3.3",
     "ora": "^4.0.3"
   },
   "peerDependencies": {
@@ -46,7 +45,7 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "npm run unit-tests",
-    "unit-tests": "jest --config test/jest.config.js ---ci -w=2",
+    "unit-tests": "jest --config test/jest.config.js ---ci -w=2 --detectOpenHandles",
     "version": "git add README.md"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "npm run unit-tests",
-    "unit-tests": "jest --config test/jest.config.js ---ci -w=2 --detectOpenHandles",
+    "unit-tests": "jest --config test/jest.config.js --ci -w=2",
     "version": "git add README.md"
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,13 +133,15 @@ function codeTransform (code, codeType) {
 /**
  * OPTIONS http method handler
  *
- * @param {object} request the Request object
+ * @param {object} _request the Request object
  * @param {object} response the Response object
+ * @param {Function} done callback function
  * @param {string} [env=prod] the IMS environment
  */
-function handleOPTIONS (request, response, env = getCliEnv()) {
+function handleOPTIONS (_request, response, done, env = getCliEnv()) {
   aioLogger.debug(`handleOPTIONS env: ${env}`)
   cors(response, env).end()
+  done()
 }
 
 /**
@@ -251,15 +253,17 @@ async function handlePOST (request, response, id, done, env = getCliEnv()) {
 /**
  * Unsupported HTTP method handler.
  *
- * @param {object} request the Request object
+ * @param {object} _request the Request object
  * @param {object} response the Response object
+ * @param {Function} done callback function
  * @param {string} [env=prod] the IMS environment
  */
-function handleUnsupportedHttpMethod (request, response, env = getCliEnv()) {
+function handleUnsupportedHttpMethod (_request, response, done, env = getCliEnv()) {
   aioLogger.debug(`handleUnsupportedHttpMethod env: ${env}`)
 
   response.statusCode = 405
   cors(response, env).end('Supported HTTP methods are OPTIONS, GET, POST')
+  done()
 }
 
 module.exports = {

--- a/src/login.js
+++ b/src/login.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims-oauth:login', { provider: 'debug' })
 const ora = require('ora')
-const { CliUx: cli } = require('@oclif/core')
+const { CliUx } = require('@oclif/core')
 const { randomId, authSiteUrl, getImsCliOAuthUrl, createServer, handleOPTIONS, handleGET, handlePOST, handleUnsupportedHttpMethod } = require('./helpers')
 const { codes: errors } = require('./errors')
 
@@ -49,11 +49,11 @@ async function login (options) {
 
     if (!bare) {
       console.log('Visit this url to log in: ')
-      cli.url(uri, uri)
+      CliUx.ux.url(uri, uri)
       spinner = ora('Waiting for browser login').start()
     }
     if (open) {
-      cli.open(uri, {
+      CliUx.ux.open(uri, {
         app
       })
     }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -232,10 +232,12 @@ test('handleUnsupportedHttpMethod', async () => {
     end: jest.fn(),
     statusCode: null
   }
+  const done = jest.fn()
 
-  handleUnsupportedHttpMethod(req, res)
+  handleUnsupportedHttpMethod(req, res, done)
   expect(res.statusCode).toEqual(405)
   expect(res.end).toHaveBeenCalled()
+  expect(done).toHaveBeenCalledTimes(1)
 })
 
 test('handleOPTIONS', async () => {
@@ -245,9 +247,11 @@ test('handleOPTIONS', async () => {
     end: jest.fn(),
     statusCode: null
   }
+  const done = jest.fn()
 
-  handleOPTIONS(req, res)
+  handleOPTIONS(req, res, done)
   expect(res.end).toHaveBeenCalled()
+  expect(done).toHaveBeenCalledTimes(1)
 })
 
 test('codeTransform', async () => {


### PR DESCRIPTION
Also, cleaned up timer leaks in the tests.
This was causing an `undefined cli.open` error in the app plugin, when you are not logged in, when you do `aio app init`.

## How Has This Been Tested?

npm test
manually tested by npm linking

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
