### PR TITLE
feat: ACNA-1854 - add IMS OAuth Server to Server plugin

### DIFF
--- a/src/ims-oauth_server_to_server.js
+++ b/src/ims-oauth_server_to_server.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const login = require('./login')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims-oauth:ims-oauth_server_to_server', { provider: 'debug' })
 const { codes: errors } = require('./errors')
 
@@ -26,10 +25,10 @@ function configMissingKeys (configData) {
 
   const missingKeys = []
   const requiredKeys = [
-    'client_id', 
-    'client_secrets', 
-    'technical_account_email', 
-    'technical_account_id', 
+    'client_id',
+    'client_secrets',
+    'technical_account_email',
+    'technical_account_id',
     'scopes',
     'ims_org_id'
   ]
@@ -76,8 +75,9 @@ async function imsLogin (ims, config) {
 
   return canSupport(config)
     .then(() => ims.getAccessTokenByClientCredentials(
-      config.client_id, config.client_secret, config.ims_org_id, config.scopes)
-    )}
+      config.client_id, config.client_secrets[0], config.ims_org_id, config.scopes)
+    )
+}
 
 module.exports = {
   canSupport,

--- a/src/ims-oauth_server_to_server.js
+++ b/src/ims-oauth_server_to_server.js
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const login = require('./login')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims-oauth:ims-oauth_server_to_server', { provider: 'debug' })
+const { codes: errors } = require('./errors')
+
+/**
+ * Checks whether the configuration data is missing any required keys.
+ *
+ * @private
+ * @param {object} configData the confiuration data to check
+ * @returns {Array} an array of missing keys, if any
+ */
+function configMissingKeys (configData) {
+  aioLogger.debug(`configMissingKeys configData: ${JSON.stringify(configData)}`)
+
+  const missingKeys = []
+  const requiredKeys = [
+    'client_id', 
+    'client_secrets', 
+    'technical_account_email', 
+    'technical_account_id', 
+    'scopes',
+    'ims_org_id'
+  ]
+
+  if (!configData) {
+    return requiredKeys
+  }
+  requiredKeys.forEach(key => {
+    if (!configData[key]) {
+      missingKeys.push(key)
+    }
+  })
+  return missingKeys
+}
+
+const canSupportSync = (configData) => configMissingKeys(configData).length === 0
+
+/**
+ * Checks whether this IMS plugin can support the config data.
+ *
+ * @param {object} configData the confiuration data to check
+ * @returns {Promise} resolves to true, if the config data is supported, rejects with an error if it's not
+ */
+async function canSupport (configData) {
+  aioLogger.debug(`canSupport configData: ${JSON.stringify(configData)}`)
+
+  const missingKeys = configMissingKeys(configData)
+  if (missingKeys.length === 0) {
+    return Promise.resolve(true)
+  } else {
+    return Promise.reject(new errors.MISSING_PROPERTIES({ messageValues: missingKeys.join(',') }))
+  }
+}
+
+/**
+ * Gets an OAuth Server to Server access token.
+ *
+ * @param {object} ims the Ims object
+ * @param {object} config the configuration data
+ * @returns {Promise<string>} a Promise with the results of the login (access token)
+ */
+async function imsLogin (ims, config) {
+  aioLogger.debug(`imsLogin config: ${JSON.stringify(config)}`)
+
+  return canSupport(config)
+    .then(() => ims.getAccessTokenByClientCredentials(
+      config.client_id, config.client_secret, config.ims_org_id, config.scopes)
+    )}
+
+module.exports = {
+  canSupport,
+  supports: canSupportSync,
+  imsLogin
+}

--- a/test/ims-oauth_server_to_server.test.js
+++ b/test/ims-oauth_server_to_server.test.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const plugin = require('../src/ims-oauth_server_to_server')
+
+const gIms = {
+  getAccessTokenByClientCredentials: jest.fn()
+}
+
+const gConfig = {
+  client_id: 'my-client-id',
+  client_secrets: ['my-client-secret'],
+  scopes: ['my', 'scopes'],
+  ims_org_id: 'my-org-id',
+  technical_account_email: 'my-tech-email',
+  technical_account_id: 'my-tech-id'
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('has ims plugin interface', () => {
+  expect(typeof plugin.supports).toEqual('function')
+  expect(typeof plugin.imsLogin).toEqual('function')
+})
+
+test('supports() interface', () => {
+  expect(plugin.supports(gConfig)).toBeTruthy()
+  expect(plugin.supports({})).toBeFalsy()
+  expect(plugin.supports()).toBeFalsy()
+})
+
+test('imsLogin() interface', async () => {
+  const myAccessToken = 'my-access-token'
+
+  gIms.getAccessTokenByClientCredentials.mockImplementation(() => {
+    return myAccessToken
+  })
+
+  // normal acceptable config
+  await expect(plugin.imsLogin(gIms, gConfig)).resolves.toEqual(myAccessToken)
+
+  // config missing a property
+  const configMissingProperties = Object.assign({}, gConfig)
+  delete configMissingProperties.client_id
+  await expect(plugin.imsLogin(gIms, configMissingProperties)).rejects.toThrow('[IMSOAuthSDK:MISSING_PROPERTIES] OAuth2 not supported due to some missing properties: client_id')
+})

--- a/test/ims-oauth_server_to_server.test.js
+++ b/test/ims-oauth_server_to_server.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Changes 📦 

- add new OAuth Server to Server (OAuth STS) plugin to handle OAuth client credentials grant type

## Pending 🚧 

- Need to update README in this repo

## Pre-requisites 🔖 

- peer dep: aio-lib-ims https://github.com/adobe/aio-lib-ims/pull/110

## How Has This Been Tested? 🔧 

- npm test
- manual tests pending

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
