### PR TITLE
Acna 3752 three legged Oauth should detect if the environment is CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@adobe/aio-lib-core-errors": "^4",
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-env": "^3",
+    "ci-info": "^4.2.0",
     "open": "^8.4.2",
     "ora": "^5.4.1"
   },

--- a/src/errors.js
+++ b/src/errors.js
@@ -47,3 +47,5 @@ module.exports = {
 E('HTTP_ERROR', 'error code=%s')
 E('MISSING_PROPERTIES', 'OAuth2 not supported due to some missing properties: %s')
 E('TIMEOUT', 'Timed out after %s seconds.')
+E('IMSOAUTHCLI_LOGIN_CI_ERROR', 'Interactive login is not supported in CI environments. Use a service account and configure credentials via environment variables. See: https://developer.adobe.com/app-builder/docs/guides/deployment/ci_cd_for_firefly_apps/')
+

--- a/src/errors.js
+++ b/src/errors.js
@@ -48,4 +48,3 @@ E('HTTP_ERROR', 'error code=%s')
 E('MISSING_PROPERTIES', 'OAuth2 not supported due to some missing properties: %s')
 E('TIMEOUT', 'Timed out after %s seconds.')
 E('IMSOAUTHCLI_LOGIN_CI_ERROR', 'Interactive login is not supported in CI environments. Use a service account and configure credentials via environment variables. See: https://developer.adobe.com/app-builder/docs/guides/deployment/ci_cd_for_firefly_apps/')
-

--- a/src/login.js
+++ b/src/login.js
@@ -30,7 +30,7 @@ const LOGIN_SUCCESS = '/login-success'
  * @param {string} [options.client_id] The client id of the OAuth2 integration.
  * @param {string} [options.scope] The scope of the OAuth2 integration.
  * @param {boolean} [options.forceLogin] If true, forces the user to log in even if they have an active session.
- * @param {boolean} [options.open=true] If true, attempts to automatically open the login URL in the default browser.
+ * @param {boolean} [options.autoOpen=true] If true, attempts to automatically open the login URL in the default browser.
  * @param {string} [options.browser] Specify the browser application to use for opening the login URL.
  * @returns {Promise<object|string>} Resolves to an access token object or an auth code string.
  */
@@ -44,7 +44,7 @@ async function login (options) {
     client_id, // eslint-disable-line camelcase
     scope,
     forceLogin,
-    open: autoOpen = true,
+    autoOpen = true,
     browser: app
   } = options
 
@@ -77,7 +77,7 @@ async function login (options) {
         spinner.start('Waiting for browser login')
       } else {
         // Non-CI, bare: No spinners. Log URI for manual use
-        console.log(`Login URI (for manual use if browser does not open automatically): ${uri}`)
+        console.error(`Login URI (for manual use if browser does not open automatically): ${uri}`)
       }
 
       if (autoOpen) {

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -106,13 +106,6 @@ beforeEach(() => {
   jest.clearAllMocks()
   stderr.start()
   ciInfo.isCI = false
-  // Clear ora mocks
-  ora.mockClear() // Clear calls to the ora() constructor itself
-  mockOraSpinnerInstance.fail.mockClear()
-  mockOraSpinnerInstance.succeed.mockClear()
-  mockOraSpinnerInstance.start.mockClear()
-  mockOraSpinnerInstance.stopAndPersist.mockClear()
-  mockOraSpinnerInstance.info.mockClear()
 })
 
 afterEach(() => {

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -324,7 +324,7 @@ test('login in CI environment (not bare)', async () => {
 
   await expect(login(config)).rejects.toThrow(new errors.codes.IMSOAUTHCLI_LOGIN_CI_ERROR())
   expect(ora).toHaveBeenCalledTimes(1) // ora constructor should be called
-  expect(mockOraSpinnerInstance.fail).toHaveBeenCalledWith('CI Environment: Interactive login not supported. Use service token/env vars for authentication.')
+  expect(mockOraSpinnerInstance.fail).toHaveBeenCalledWith('CI Environment: Interactive login not supported. Use technical account via env vars for authentication. For guidance, see https://github.com/adobe/aio-apps-action')
   expect(open).not.toHaveBeenCalled() // Ensure browser open was not attempted
 })
 

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -16,11 +16,13 @@ const open = require('open')
 const login = require('../src/login')
 const url = require('url')
 const { stderr } = require('stdout-stderr')
+const ciInfo = require('ci-info')
 
 // //////////////////////////////////////////
 
 jest.mock('../src/helpers')
 jest.mock('open', () => jest.fn())
+jest.mock('ci-info')
 
 const gConfig = {
   client_id: 'my-client-id',
@@ -85,6 +87,7 @@ afterAll(() => {
 beforeEach(() => {
   jest.clearAllMocks()
   stderr.start()
+  ciInfo.isCI = false
 })
 
 afterEach(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #110

## Description

The fix involves adding `ci-info` package as a dependency and modify the login to be CI-aware by checking if the code is running in a CI environment( ex:` if (ciInfo.isCI)` )

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 ACNA ticket: [ ACNA-3752](https://jira.corp.adobe.com/browse/ACNA-3752)
Related Github issue: https://github.com/adobe/aio-lib-ims-oauth/issues/110

## Motivation and Context

The core problem is that when user attempts an OAuth login  in a CI/CD environment, the process hangs and eventually times out. This happens because the library tries to spawn a browser for interactive login , which is not possible in a headless CI environment.

## How Has This Been Tested?

- Verified that the existing unit tests for the original non-CI path still pass
- Added new unit tests to cover the CI path
-  If CI env is detected, a descriptive error msg that states interactive OAuth login not supported

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
