### PR TITLE
feat: make local login port configurable via AIO_IMS_LOCAL_LOGIN_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ For example as shown in the following screenshot editing the credential:
 
 ![Edit Credential](docs/images/developer-console-edit-credential.png "Developer Console: edit credential")
 
+# Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AIO_IMS_LOCAL_LOGIN_PORT` | The port number for the local login server. Useful for Docker environments where a specific port needs to be forwarded. Must be a valid number; falls back to `0` (OS-assigned) if not set or invalid. | `0` |
+
+For example, to run `aio login` inside a Docker container with port forwarding:
+
+```bash
+export LOCAL_LOGIN_PORT=8080
+docker run --rm -it -p ${LOCAL_LOGIN_PORT}:${LOCAL_LOGIN_PORT} -e AIO_IMS_LOCAL_LOGIN_PORT=${LOCAL_LOGIN_PORT} node:24-slim sh -c "npm install -g @adobe/aio-cli && bash"
+```
+
 # Contributing
 Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,8 @@ async function createServer () {
   return new Promise(resolve => {
     const server = http.createServer()
 
-    server.listen(0, '127.0.0.1')
+    const port = Number(process.env.AIO_IMS_LOCAL_LOGIN_PORT) || 0
+    server.listen(port, '127.0.0.1')
     server.on('listening', () => {
       resolve(server)
     })

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -133,6 +133,49 @@ test('createServer', async () => {
   })
 
   await expect(createServer()).resolves.toEqual(server)
+  expect(server.listen).toHaveBeenCalledWith(0, '127.0.0.1')
+})
+
+test('createServer - AIO_IMS_LOCAL_LOGIN_PORT set to valid number', async () => {
+  const server = {
+    listen: jest.fn(),
+    close: jest.fn(),
+    on: jest.fn((event, callback) => {
+      if (event === 'listening') {
+        setTimeout(callback, 100)
+      }
+    })
+  }
+
+  http.createServer.mockImplementation((_) => {
+    return server
+  })
+
+  process.env.AIO_IMS_LOCAL_LOGIN_PORT = '8080'
+  await expect(createServer()).resolves.toEqual(server)
+  expect(server.listen).toHaveBeenCalledWith(8080, '127.0.0.1')
+  delete process.env.AIO_IMS_LOCAL_LOGIN_PORT
+})
+
+test('createServer - AIO_IMS_LOCAL_LOGIN_PORT set to invalid value', async () => {
+  const server = {
+    listen: jest.fn(),
+    close: jest.fn(),
+    on: jest.fn((event, callback) => {
+      if (event === 'listening') {
+        setTimeout(callback, 100)
+      }
+    })
+  }
+
+  http.createServer.mockImplementation((_) => {
+    return server
+  })
+
+  process.env.AIO_IMS_LOCAL_LOGIN_PORT = 'notanumber'
+  await expect(createServer()).resolves.toEqual(server)
+  expect(server.listen).toHaveBeenCalledWith(0, '127.0.0.1')
+  delete process.env.AIO_IMS_LOCAL_LOGIN_PORT
 })
 
 test('stringToJson', () => {


### PR DESCRIPTION
## Summary

- Adds support for `AIO_IMS_LOCAL_LOGIN_PORT` environment variable to configure the local login server port
- Falls back to port `0` (OS-assigned) if the env var is not set or is not a valid number
- Documents the new env var in the README with a Docker usage example

Closes #118

## Test plan

- [x] Existing `createServer` test updated to assert port `0` is used by default
- [x] New test: valid port number (`8080`) is passed to `server.listen`
- [x] New test: invalid value (`notanumber`) falls back to port `0`
- [x] All tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)